### PR TITLE
Support workspaces that contain a package at the root

### DIFF
--- a/tests/empty.rs
+++ b/tests/empty.rs
@@ -15,15 +15,11 @@ fn empty() -> Result<(), Box<dyn std::error::Error>> {
         "channel: 1.62
 latest rust-version: 1.62
 {0}: reading
-{0}: updating rust-version: None => 1.62
 ",
         manifest.path().to_string_lossy()
     ));
 
-    manifest.assert(
-        r#"package = { rust-version = "1.62" }
-"#,
-    );
+    manifest.assert("");
 
     Ok(())
 }

--- a/tests/workspace_with_dot.rs
+++ b/tests/workspace_with_dot.rs
@@ -1,0 +1,60 @@
+use assert_cmd::prelude::*;
+use assert_fs::prelude::*;
+use std::process::Command;
+
+#[test]
+fn workspace() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = assert_fs::TempDir::new()?;
+    let manifest = temp.child("Cargo.toml");
+    manifest.write_str(
+        r#"
+[workspace]
+members = [".", "b"]
+
+[package]
+rust-version = "1.60"
+"#,
+    )?;
+    let manifest_b = temp.child("b/Cargo.toml");
+    manifest_b.write_str(
+        r#"
+[package]
+rust-version = "1.62"
+"#,
+    )?;
+
+    let mut cmd = Command::cargo_bin("cargo-set-rust-version")?;
+    cmd.arg("set-rust-version");
+    cmd.arg("--manifest").arg(manifest.path());
+    cmd.arg("--channel").arg("1.62");
+    cmd.assert().success().stdout(format!(
+        "channel: 1.62
+latest rust-version: 1.62
+{0}: reading
+{0}: updating rust-version: 1.60 => 1.62
+{0}: found workspace
+{1}: reading
+{1}: up-to-date rust-version: 1.62
+",
+        manifest.path().to_string_lossy(),
+        manifest_b.path().to_string_lossy(),
+    ));
+
+    manifest.assert(
+        r#"
+[workspace]
+members = [".", "b"]
+
+[package]
+rust-version = "1.62"
+"#,
+    );
+    manifest_b.assert(
+        r#"
+[package]
+rust-version = "1.62"
+"#,
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### What
Support workspaces that contain a package at the root.

### Why
If a workspace has a package at the root, and therefore a member with path `.`, the tool recurses infinitely.

The tool needs to treat each manifest as possibly a package, and then in addition to that look for a workspace definition for other manifests to load, excluding itself if it is listed in the member list.